### PR TITLE
fix: wrong peer dependency notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "author": "Benjie Gillam <code@benjiegillam.com>",
   "license": "MIT",
   "peerDependencies": {
-    "graphql": "15.x | 16.x | 17.x"
+    "graphql": "15.x || 16.x || 17.x"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.7",


### PR DESCRIPTION
`"graphql": "15.x | 16.x | 17.x"` is an invalid peer dependency notation and will actually lead to an npm error:
```
npm error
npm error Could not resolve dependency:
npm error peer graphql@"15.x | 16.x | 17.x" from graphql-sock@1.0.0
```